### PR TITLE
ci: Run the rust-workflow on PRs to any branch

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -4,9 +4,9 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
-    tags: [ "*" ]
+    tags: [ "**" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "**" ]
 
 # Make sure there is no pipeline running uselessly.
 concurrency:


### PR DESCRIPTION
The `on` part states that it will run on PRs to any branch, but the `*` wildcard does not match forward slashes, for that we need to use `**`. This closes #14.